### PR TITLE
Python 3.6 not available by default in Ubuntu 20.04

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -34,5 +34,14 @@ jobs:
         with:
           scenario: ${{ matrix.scenario }}
 
-# notifications:
-#   webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  publish:
+    name: Galaxy
+    if: startsWith(github.ref, 'refs/tags')
+    needs:
+      - test
+    runs-on: ubuntu-20.04
+    steps:
+      - name: galaxy
+        uses: ome/action-ansible-galaxy-publish@main
+        with:
+          galaxy-api-key: ${{ secrets.GALAXY_API_KEY }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -30,8 +30,22 @@ jobs:
         scenario: ${{fromJson(needs.list-scenarios.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      # Ansible 2.6 has problems when the remote python version is 3
+      - name: Install ome-ansible-molecule
+        run: |
+          if [ $SCENARIO = interpreter-py2 ]; then
+            python -mpip install 'ome-ansible-molecule==0.4.*'
+          else
+            python -mpip install ansible==2.8.3 molecule==2.22 docker==4.4.1
+          fi
+        env:
+          SCENARIO: ${{ matrix.scenario }}
       - uses: ome/action-ome-ansible-molecule@main
         with:
+          manage-virtualenv: "false"
           scenario: ${{ matrix.scenario }}
 
 # notifications:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -30,22 +30,8 @@ jobs:
         scenario: ${{fromJson(needs.list-scenarios.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      # Ansible 2.6 has problems when the remote python version is 3
-      - name: Install ome-ansible-molecule
-        run: |
-          if [ $SCENARIO = interpreter-py2 ]; then
-            python -mpip install 'ome-ansible-molecule==0.4.*'
-          else
-            python -mpip install ansible==2.8.3 molecule==2.22 docker==4.4.1
-          fi
-        env:
-          SCENARIO: ${{ matrix.scenario }}
       - uses: ome/action-ome-ansible-molecule@main
         with:
-          manage-virtualenv: "false"
           scenario: ${{ matrix.scenario }}
 
 # notifications:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 Python3 Virtualenv
 ==================
 
-
-[![Build Status](https://travis-ci.org/ome/ansible-role-python3-virtualenv.svg)](https://travis-ci.org/ome/ansible-role-python3-virtualenv)
-[![Ansible Role TODO](https://img.shields.io/ansible/role/TODO.svg)](https://galaxy.ansible.com/ome/python3_-_virtualenv/)
+[![Actions Status](https://github.com/ome/ansible-role-python3-virtualenv/workflows/Molecule/badge.svg)](https://github.com/ome/ansible-role-python3-virtualenv/actions)
+[![Ansible Role TODO](https://img.shields.io/ansible/role/47139.svg)](https://galaxy.ansible.com/ome/python3_virtualenv/)
 
 Install Python3 virtualenv dependencies and a wrapper script for the Ansible pip module.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - focal
   galaxy_tags:
     - system
     - python

--- a/molecule/interpreter-py3/molecule.yml
+++ b/molecule/interpreter-py3/molecule.yml
@@ -16,6 +16,10 @@ platforms:
     image: ubuntu:18.04
     groups:
       - py3
+  - name: interpreter-py3-u2004
+    image: ubuntu:20.04
+    groups:
+      - py3
 
 provisioner:
   name: ansible

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: python3 venv | install python3
+- name: python3 venv | install python3 (3.6 Ubuntu 18)
   become: true
   apt:
     name:
@@ -10,6 +10,23 @@
       - python3-pip
       - python3-setuptools
     state: present
+  when:
+    - ansible_os_family | lower == 'debian'
+    - ansible_distribution_major_version == 18
+
+- name: python3 venv | install python3 (3.8 Ubuntu 20)
+  become: true
+  apt:
+    name:
+      - python3.8
+      - python3.8-distutils
+      - python3.8-venv
+      - python3-pip
+      - python3-setuptools
+    state: present
+  when:
+    - ansible_os_family | lower == 'debian'
+    - ansible_distribution_major_version == 20      
 
 # https://docs.ansible.com/ansible/latest/modules/pip_module.html
 # The setuptools package must be installed for both the Ansible Python

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,32 +1,16 @@
 ---
 
-- name: python3 venv | install python3 (3.6 Ubuntu 18)
+- name: python3 venv | install python3
   become: true
   apt:
     name:
-      - python3.6
-      - python3.6-distutils
-      - python3.6-venv
+      - python3
+      - python3-distutils
+      - python3-venv
       - python3-pip
       - python3-setuptools
     state: present
-  when:
-    - ansible_os_family | lower == 'debian'
-    - ansible_distribution_major_version == '18'
 
-- name: python3 venv | install python3 (3.8 Ubuntu 20)
-  become: true
-  apt:
-    name:
-      - python3.8
-      - python3.8-distutils
-      - python3.8-venv
-      - python3-pip
-      - python3-setuptools
-    state: present
-  when:
-    - ansible_os_family | lower == 'debian'
-    - ansible_distribution_major_version == '20'
 
 # https://docs.ansible.com/ansible/latest/modules/pip_module.html
 # The setuptools package must be installed for both the Ansible Python

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -3,6 +3,7 @@
 - name: python3 venv | install python3
   become: true
   apt:
+    update_cache: yes
     name:
       - python3
       - python3-distutils

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -26,7 +26,7 @@
     state: present
   when:
     - ansible_os_family | lower == 'debian'
-    - ansible_distribution_major_version == '20'      
+    - ansible_distribution_major_version == '20'
 
 # https://docs.ansible.com/ansible/latest/modules/pip_module.html
 # The setuptools package must be installed for both the Ansible Python

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -3,7 +3,7 @@
 - name: python3 venv | install python3
   become: true
   apt:
-    update_cache: yes
+    update_cache: true
     name:
       - python3
       - python3-distutils

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -12,7 +12,7 @@
     state: present
   when:
     - ansible_os_family | lower == 'debian'
-    - ansible_distribution_major_version == 18
+    - ansible_distribution_major_version == '18'
 
 - name: python3 venv | install python3 (3.8 Ubuntu 20)
   become: true
@@ -26,7 +26,7 @@
     state: present
   when:
     - ansible_os_family | lower == 'debian'
-    - ansible_distribution_major_version == 20      
+    - ansible_distribution_major_version == '20'      
 
 # https://docs.ansible.com/ansible/latest/modules/pip_module.html
 # The setuptools package must be installed for both the Ansible Python


### PR DESCRIPTION
I added an ansible task to install python 3.8 when the ansible_ditribution_major_version is 20. And made the installation of 3.6 dependent on the ansible_distribution_major_version being 18.

Wasn't sure if this was preferred, or it would be better to add the deadsnakes repo and install python 3.6?
